### PR TITLE
tmpfile package added

### DIFF
--- a/tmpfile/tmpfile.go
+++ b/tmpfile/tmpfile.go
@@ -1,0 +1,147 @@
+package tmpfile
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/odeke-em/go-uuid"
+)
+
+type readSeekerAt interface {
+	io.ReadSeeker
+	ReadAt(b []byte, off int64) (int, error)
+}
+
+type readSeekerAtWriteCloser interface {
+	readSeekerAt
+	io.WriteCloser
+}
+
+type statInfoer interface {
+	Stat() (os.FileInfo, error)
+}
+
+type readSeekerCloseWriterStatInfoer interface {
+	readSeekerAtWriteCloser
+	statInfoer
+}
+
+var _ readSeekerCloseWriterStatInfoer = &TmpFile{}
+
+type TmpFile struct {
+	tmpf          *os.File
+	dir           string
+	path          string
+	doneOnce      sync.Once
+	ownCreatedDir bool
+}
+
+func (tf TmpFile) Done() error {
+	var err error
+	tf.doneOnce.Do(func() {
+		_ = tf.tmpf.Close()
+		targetPath := tf.tmpf.Name()
+		if tf.ownCreatedDir {
+			// Since we are removing the entire dir,
+			// any file in the dir will be cleaned out.
+			targetPath = tf.dir
+		}
+		err = os.RemoveAll(targetPath)
+	})
+	return err
+}
+
+type Context struct {
+	Suffix            string
+	Dir               string
+	CreateIsolatedDir bool
+	// NoOverrideIfSuffixEmpty if set signifies that the caller does not want
+	// any suffix to be created for them if no suffix was previously provided,
+	// that is they want to main the empty suffix.
+	NoOverrideIfSuffixEmpty bool
+}
+
+func New(ctx *Context) (*TmpFile, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("nil context passed in")
+	}
+
+	dir := ctx.Dir
+	var abortFn func() error
+	ownCreatedDir := false
+	if ctx.CreateIsolatedDir {
+		dir = filepath.Join(os.Getenv("TMPDIR"), dir, uuid.UUID4().String())
+		abortFn = func() error { return os.RemoveAll(dir) }
+		ownCreatedDir = true
+	}
+
+	if _, err := os.Stat(dir); err != nil {
+		if dir != "" {
+			if !os.IsNotExist(err) {
+				return nil, err
+			}
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	suffix := ctx.Suffix
+	if ctx.Suffix == "" && !ctx.NoOverrideIfSuffixEmpty {
+		suffix = uuid.UUID4().String()
+	}
+
+	tmpf, err := ioutil.TempFile(dir, suffix)
+	if err != nil {
+		if abortFn != nil {
+			_ = abortFn()
+		}
+		return nil, err
+	}
+	ttmpf := new(TmpFile)
+	ttmpf.tmpf = tmpf
+	ttmpf.ownCreatedDir = ownCreatedDir
+	ttmpf.path = filepath.Join(dir, tmpf.Name())
+	return ttmpf, nil
+}
+
+// Invoke this function to create a temp file in an isolated directory
+func NewInIsolatedDir() (*TmpFile, error) {
+	return New(&Context{CreateIsolatedDir: true})
+}
+
+func (tf *TmpFile) Write(b []byte) (int, error) {
+	return tf.tmpf.Write(b)
+}
+
+func (tf *TmpFile) Close() error {
+	return tf.tmpf.Close()
+}
+
+func (tf *TmpFile) Name() string {
+	return tf.tmpf.Name()
+}
+
+func (tf *TmpFile) Path() string {
+	return tf.path
+}
+
+func (tf *TmpFile) ReadAt(b []byte, off int64) (int, error) {
+	return tf.tmpf.ReadAt(b, off)
+}
+
+func (tf *TmpFile) Read(b []byte) (int, error) {
+	return tf.tmpf.Read(b)
+}
+
+func (tf *TmpFile) Seek(offset int64, whence int) (ret int64, err error) {
+	return tf.tmpf.Seek(offset, whence)
+}
+
+func (tf *TmpFile) Stat() (os.FileInfo, error) {
+	return tf.tmpf.Stat()
+}

--- a/tmpfile/tmpfile_test.go
+++ b/tmpfile/tmpfile_test.go
@@ -1,0 +1,86 @@
+package tmpfile
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestTmpFile(t *testing.T) {
+	testCases := [...]struct {
+		ctx     *Context
+		wantErr bool
+	}{
+		0: {ctx: nil, wantErr: true},
+		1: {ctx: &Context{}},
+		2: {ctx: &Context{
+			CreateIsolatedDir: true,
+			Suffix:            "tmpf",
+		}},
+		3: {ctx: &Context{
+			CreateIsolatedDir: true,
+			Suffix:            "",
+		}},
+		4: {ctx: &Context{
+			Dir:    "here",
+			Suffix: "",
+		}},
+		5: {ctx: &Context{
+			Dir:    "./here",
+			Suffix: "",
+		}},
+		6: {ctx: &Context{
+			Dir:    " ",
+			Suffix: "",
+		}},
+		7: {ctx: &Context{
+			Dir:    "..",
+			Suffix: "",
+		}},
+		8: {ctx: &Context{
+			Dir:               "tx1",
+			Suffix:            "",
+			CreateIsolatedDir: true,
+		}},
+	}
+
+	for i, tt := range testCases {
+		tmpf, err := New(tt.ctx)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d: got nil err, want non-nil err", i)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("#%d: got err=%v, want nil err", i, err)
+			}
+			if tmpf == nil {
+				t.Fatalf("#%d: got nil tempfile, want non-nil tempfile", i)
+			}
+
+			externStatInfo, err := os.Stat(tmpf.Name())
+			if err != nil {
+				t.Errorf("#%d: got statErr=%v, expected nil stat error", i, err)
+			} else {
+				gotSys := externStatInfo.Sys()
+				iStatInfo, err := tmpf.Stat()
+				if err != nil {
+					t.Fatalf("#%d: tmpf.Stat() err=%v, expected nil error", i, err)
+				}
+				iSys := iStatInfo.Sys()
+				if !reflect.DeepEqual(iSys, gotSys) {
+					t.Errorf("#%d: tmpfSys=%q os.StatByNameSys=%q", i, iSys, gotSys)
+				}
+			}
+		}
+
+		if tmpf != nil {
+			// Invoke done more than once to ensure it fires only once
+			for j := 0; j < 4; j++ {
+				if err := tmpf.Done(); err != nil {
+					t.Fatalf("#%d, Done.Try #%d: done.Err=%v expected non-nil error", i, j, err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added a package for tmpfile usage and management. It exposes a few methods
of the underlying temp file like:
- Read
- Seek
- ReadAt
- Write
- Close
- Stat

But also the management of this package kicks in when you invoke
`.Done()` which runs exactly once and removes the file.

This package exposes two different flavours of usage:
- NewInIsolatedDir - Use this in packages for which you'd just to use a
  unique temp file in an isolated directory, Read from, Write to it and
  discard it at the end
  Sample usage

``` go
tmpf, err := tmpfile.NewInIsolatedDir()
if err != nil {
  return nil, err
}

defer tmpf.Done() // Cleanup after self.
if _, err = io.Copy(tmpf, cipherSource); err != nil {
  return nil, err
}
```
- New - Use this in situations where you'd like flexibility on suffix
  and location of directory/temp file.
  Sample usage

``` go
tmpf, err := tmpfile.New(&tmpfile.Context{
  Dir: "trims",
  Suffix: "mkv",
  CreateInIsolatedDir: true,
})
if err != nil {
  return nil, err
}

defer tmpf.Done() // Cleanup after self.
if _, err = io.Copy(tmpf, mediaRes.Body); err != nil {
  return nil, err
}
```
